### PR TITLE
Inherited Enumberable Prop checks, variable for declared strong attrs, and Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,95 @@
-# Ember-strong-attrs
+# Ember Strong Attrs
 
-This README outlines the details of collaborating on this Ember addon.
+Ember Strong Attrs is an addon that facilitates the declaration of
+`Ember.Component` required and optional attributes. It extends
+`Ember.Component` and provides [ES7 Decorators][decorators] to declare
+**required** and **optional** attributes.
 
-## Installation
+## Caveats
 
-* `git clone` this repository
-* `npm install`
-* `bower install`
+- You need to enable [ES7 Decorators][decorators] in Babel.
+- [JSHint does not support ES7 Decorators at the moment] so you
+  will get JSHint errors like this: ` Unexpected '@'.`.
+- Your `Ember.Component` needs to be ES6 classes so that the ES7 Decorators can
+  decorate them.
 
-## Running
+## Setup
 
-* `ember server`
-* Visit your app at http://localhost:4200.
+1. Install the addon
+  ```
+  ember install --save-dev ember-strong-attrs
+  ```
+2. Update your `ember-cli-build.js` to enable Babel's ES7 Decorators
+  ```js
+  /* global require, module */
+  var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
-## Running Tests
+  module.exports = function(defaults) {
+    defaults.babel = {
+      optional: ['es7.decorators']
+    };
 
-* `ember test`
-* `ember test --server`
+    var app = new EmberApp(defaults, {});
 
-## Building
+    return app.toTree();
+  };
+  ```
+3. Update the components you want to declare required/option attributes on to
+   use [ES6 Classes syntax][classes].
 
-* `ember build`
+  Given the following `Ember.Component` definition:
+  ```js
+  import Ember from 'ember';
 
-For more information on using ember-cli, visit [http://www.ember-cli.com/](http://www.ember-cli.com/).
+  export default Ember.Component.extend({
+    // ... your methods and props
+  });
+  ```
+
+  You will get the following using [ES6 Classes syntax][classes];
+  ```js
+  import Ember from 'ember';
+
+  export default class Ember.Component.extend({ // Note the class keyword
+    // ... your methods and props
+  }) { } // Don't forget the trailing { } and the removal of the semicolon
+  ```
+4. Import the decorators into your component file.
+  ```js
+  import { requiredAttr, optionalAttr } from 'ember-strong-attrs';
+  ```
+
+## API
+
+Ember Strong Attrs exposes two decorators:
+
+- `@requiredAttrs(attrName, attrType)`
+- `@optionalAttrs(attrName, attrType)`
+
+The `attrType` argument can be the following classes:
+
+- `String`
+- `Number`
+- `Date`
+- `Function`
+- `YouCustomClass`
+
+Example:
+
+```js
+import Ember from 'ember';
+import { requiredAttr, optionalAttr } from 'ember-strong-attrs';
+import Person from '../models/person';
+
+// Note the lack of semicolons behind the decorators
+@requiredAttr('myRequiredAttr', String)
+@optionalAttr('myStringAttr', String)
+@optionalAttr('myPersonAttr', Person)
+export default class Ember.Component.extend({
+  // ... your methods and props
+}) { }
+```
+
+[decorators]:https://github.com/wycats/javascript-decorators
+[jshint-no-decorators]:http://jshint.com/blog/new-lang-features/
+[classes]:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
 
-var extendedComponent = false;
+let declaredStrongAttrsKey = 'declaredStrongAttrs';
+let extendedComponent = false;
 
 if (!extendedComponent) {
   Ember.Component.reopen({
     checkStrongAttrs: Ember.on('init', function() {
-      const declaredStrongAttrs = this.constructor.superclass.declaredStrongAttrs;
+      const declaredStrongAttrs = this.constructor.superclass[declaredStrongAttrsKey];
 
       if (!declaredStrongAttrs) { return; }
 
@@ -42,7 +43,7 @@ export function optionalAttr(attrName, attrType) {
 function declareAttr(target, attrName, attrType, isRequired) {
   ensureDeclaredStrongAttrs(target);
 
-  target.declaredStrongAttrs.push({
+  target[declaredStrongAttrsKey].push({
     name: attrName,
     type: attrType,
     required: isRequired
@@ -80,13 +81,13 @@ function throwInvalidTypeError(declaredAttr, val, component) {
 function ensureDeclaredStrongAttrs(target) {
   let missingDeclaredStrongsAttrs = true;
   for (let prop in target) {
-    if (prop === 'declaredStrongAttrs') {
+    if (prop === declaredStrongAttrsKey) {
       missingDeclaredStrongsAttrs = false;
     }
   }
 
   if (missingDeclaredStrongsAttrs) {
-    Object.defineProperty(target, 'declaredStrongAttrs', {
+    Object.defineProperty(target, declaredStrongAttrsKey, {
       writable: false,
       configurable: false,
       enumerable: true,

--- a/addon/index.js
+++ b/addon/index.js
@@ -4,7 +4,7 @@ var extendedComponent = false;
 
 if (!extendedComponent) {
   Ember.Component.reopen({
-    checkStrongAttrs: Ember.on('init', function(){
+    checkStrongAttrs: Ember.on('init', function() {
       const declaredStrongAttrs = this.constructor.superclass.declaredStrongAttrs;
 
       if (!declaredStrongAttrs) { return; }
@@ -33,21 +33,14 @@ export function requiredAttr(attrName, attrType) {
   };
 }
 
-export function optionalAttr(attrName, attrType){
+export function optionalAttr(attrName, attrType) {
   return function(target) {
     declareAttr(target, attrName, attrType, false);
   };
 }
 
 function declareAttr(target, attrName, attrType, isRequired) {
-  if (!target.declaredStrongAttrs) {
-    Object.defineProperty(target, 'declaredStrongAttrs', {
-      writable: false,
-      configurable: false,
-      enumerable: true,
-      value: []
-    });
-  }
+  ensureDeclaredStrongAttrs(target);
 
   target.declaredStrongAttrs.push({
     name: attrName,
@@ -56,7 +49,7 @@ function declareAttr(target, attrName, attrType, isRequired) {
   });
 }
 
-function validateType(declaredAttr, val, component){
+function validateType(declaredAttr, val, component) {
   switch (declaredAttr.type) {
     case String:
       if (Ember.typeOf(val) !== 'string') {
@@ -82,6 +75,24 @@ function validateType(declaredAttr, val, component){
 
 function throwInvalidTypeError(declaredAttr, val, component) {
   throw new Error(`Component ${component.toString()} expected attribute '${declaredAttr.name}' to be of type '${typeToString(declaredAttr.type)}'. Was '${val}'`);
+}
+
+function ensureDeclaredStrongAttrs(target) {
+  let missingDeclaredStrongsAttrs = true;
+  for (let prop in target) {
+    if (prop === 'declaredStrongAttrs') {
+      missingDeclaredStrongsAttrs = false;
+    }
+  }
+
+  if (missingDeclaredStrongsAttrs) {
+    Object.defineProperty(target, 'declaredStrongAttrs', {
+      writable: false,
+      configurable: false,
+      enumerable: true,
+      value: []
+    });
+  }
 }
 
 function typeToString(type) {

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,28 +1,33 @@
 import Ember from 'ember';
 
 var extendedComponent = false;
+
 if (!extendedComponent) {
   Ember.Component.reopen({
     checkStrongAttrs: Ember.on('init', function(){
       const declaredStrongAttrs = this.constructor.superclass.declaredStrongAttrs;
+
       if (!declaredStrongAttrs) { return; }
+
       declaredStrongAttrs.forEach((declaredAttr) => {
         const val = this.getAttr(declaredAttr.name);
         const isUndefined = val === undefined;
+
         if (isUndefined && declaredAttr.required) {
           throw new Error(`Component ${this.toString()} missing required attribute '${declaredAttr.name}'. Expected type '${typeToString(declaredAttr.type)}'`)
         }
+
         if (declaredAttr.type && !isUndefined) {
           validateType(declaredAttr, val, this);
         }
       });
     })
   });
+
   extendedComponent = true;
 }
 
-
-export function requiredAttr(attrName, attrType){
+export function requiredAttr(attrName, attrType) {
   return function(target) {
     declareAttr(target, attrName, attrType, true);
   };
@@ -43,6 +48,7 @@ function declareAttr(target, attrName, attrType, isRequired) {
       value: []
     });
   }
+
   target.declaredStrongAttrs.push({
     name: attrName,
     type: attrType,


### PR DESCRIPTION
Added new lines for easier visual code logical segment detection.

Added function to use `for ... in` to check for `declaredStrongAttrsKey` on target. `for ... in` iterates over inherited enumerable properties while `hasOwnProperty` only checks the object's direct properties.
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in

JSHint has no intention of support ES7 decorators for awhile so I added that to the README.
- https://github.com/jshint/jshint/issues/2297
- https://github.com/jshint/jshint/issues/2310
- http://jshint.com/blog/new-lang-features/

Add initial docs to README.
