### PR TITLE
Use full URL to repo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "ember build",
     "test": "ember try:testall"
   },
-  "repository": "yapplabs/ember-strong-attrs",
+  "repository": "https://github.com/yapplabs/ember-strong-attrs",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
This should let npmjs.org get the right URL for the repo; right now it's skipping the Github fragment in `package.json` and using the first URL it finds in the `README`.
